### PR TITLE
Adapt the autocmake project for MS Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Build Status](https://travis-ci.org/scisoft/autocmake.svg?branch=master)](https://travis-ci.org/scisoft/autocmake/builds) [![Documentation Status](https://readthedocs.org/projects/autocmake/badge/?version=latest)](http://autocmake.readthedocs.org)
 
+MiroI build statuses:
+[![Build Status](https://travis-ci.org/miroi/autocmake.svg?branch=master)](https://travis-ci.org/miroi/autocmake/builds)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/miroi/autocmake?branch=master&svg=true)](https://ci.appveyor.com/project/miroi/autocmake)
+
 
 # Autocmake
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: 1.0.{build}
+init:
+- ps: >-
+    mkdir C:\software
+  
+    cd C:\software
+
+    wget http://netcologne.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-posix/seh/x86_64-4.9.2-release-posix-seh-rt_v4-rev2.7z -OutFile MinGW.7z
+
+    7z x MinGW.7z > log_mingw.txt
+    
+    wget https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+    
+    python get-pip.py
+    
+    pip install pytest
+    
+    cd C:\projects\autocmake
+environment:
+  path: C:\Perl\site\bin;C:\Perl\bin;C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files (x86)\Mercurial;C:\Program Files\7-Zip;C:\Progr am Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\Microsoft SQL Server\110\Tools\Binn\;C:\Program Files (x86)\Microsoft ASP.NET\ASP.NET Web Pages \v1.0\;C:\Program Files (x86)\Microsoft SDKs\Windows Azure\CLI\wbin;C:\Program Files (x86)\MSBuild\12.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Tools\xUnit;C:\T ools\NUnit\bin;C:\Tools\NuGet;C:\Python27;C:\Python27\Scripts;C:\Program Files (x86)\Microsoft SQL Server\100\Tools\Binn\;C:\Program Files\Microsoft SQL Server\100\Tools\Binn\;C:\Program Files\Microsoft SQL Server\100\DTS\Binn\;C:\Program Files (x86 )\Microsoft SQL Server\100\Tools\Binn\VSShell\Common7\IDE\;C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\IDE\PrivateAssemblies\;C:\Program Files (x86)\Microsoft SQL Server\100\DTS\Binn\;C:\Program Files (x86)\Microso ft SQL Server\110\Tools\Binn\;C:\Program Files\Microsoft SQL Server\110\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\110\Tools\Binn\ManagementStudio\;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE\Privat eAssemblies\;C:\Program Files (x86)\Microsoft SQL Server\110\DTS\Binn\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\110\Tools\Binn\;C:\Program Files (x86)\Microsoft S QL Server\120\Tools\Binn\;C:\Program Files\Microsoft SQL Server\120\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\120\Tools\Binn\ManagementStudio\;C:\Program Files (x86)\Microsoft SQL Server\120\DTS\Binn\;C:\Tools\WebDriv er;C:\Program Files\Microsoft\Web Platform Installer\;C:\Tools\MSpec;C:\Program Files\nodejs;C:\Program Files (x86)\nodejs;C:\Program Files\Java\jdk1.7.0\bin;C:\ProgramData\chocolatey\bin;C:\Tools\GitVersion;C:\Program Files (x86 )\Microsoft Fxcop 10.0;C:\Program Files (x86)\Git\cmd;C:\Program Files (x86)\CollabNet\Subversion Client;C:\Program Files (x86)\iojs;C:\Program Files\iojs;C:\Users\appveyor\AppData\Roaming\npm;C:\Pr ogram Files (x86)\Microsoft SDKs\TypeScript\1.4\;C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.0\;C:\Ruby193\bin;C:\Program Files (x86)\CMake\bin;C:\go\bin;C:\Tools\Coverity\bin;C:\Program Files\erl6.3\bin;C:\Chocolatey\bin;C:\Program Files\AppVeyor\BuildAgent;C:\software\mingw64\bin
+build_script:
+- set PYTHONPATH=%PYTHONPATH%;%cd%
+- py.test test/test.py

--- a/test/cxx/cmake/autocmake.cfg
+++ b/test/cxx/cmake/autocmake.cfg
@@ -2,15 +2,15 @@
 name: example
 
 [cxx]
-source: https://github.com/miroi/autocmake/raw/master/modules/cxx.cmake
+source: https://github.com/scisoft/autocmake/raw/master/modules/cxx.cmake
 docopt: --cxx=<CXX> C++ compiler [default: g++].
         --extra-cxx-flags=<EXTRA_CXXFLAGS> Extra C++ compiler flags [default: ''].
 define: ' CXX=%s' % arguments['--cxx']
         '-DEXTRA_CXXFLAGS="%s"' % arguments['--extra-cxx-flags']
 
 [default_build_paths]
-source: https://github.com/miroi/autocmake/raw/master/modules/default_build_paths.cmake
+source: https://github.com/scisoft/autocmake/raw/master/modules/default_build_paths.cmake
 
 [src]
-source: https://github.com/miroi/autocmake/raw/master/modules/src.cmake
+source: https://github.com/scisoft/autocmake/raw/master/modules/src.cmake
 

--- a/test/cxx/cmake/autocmake.cfg
+++ b/test/cxx/cmake/autocmake.cfg
@@ -2,14 +2,15 @@
 name: example
 
 [cxx]
-source: https://github.com/scisoft/autocmake/raw/master/modules/cxx.cmake
+source: https://github.com/miroi/autocmake/raw/master/modules/cxx.cmake
 docopt: --cxx=<CXX> C++ compiler [default: g++].
         --extra-cxx-flags=<EXTRA_CXXFLAGS> Extra C++ compiler flags [default: ''].
-export: 'CXX=%s' % arguments['--cxx']
-define: '-DEXTRA_CXXFLAGS="%s"' % arguments['--extra-cxx-flags']
+define: ' CXX=%s' % arguments['--cxx']
+        '-DEXTRA_CXXFLAGS="%s"' % arguments['--extra-cxx-flags']
 
 [default_build_paths]
-source: https://github.com/scisoft/autocmake/raw/master/modules/default_build_paths.cmake
+source: https://github.com/miroi/autocmake/raw/master/modules/default_build_paths.cmake
 
 [src]
-source: https://github.com/scisoft/autocmake/raw/master/modules/src.cmake
+source: https://github.com/miroi/autocmake/raw/master/modules/src.cmake
+

--- a/test/fc/cmake/autocmake.cfg
+++ b/test/fc/cmake/autocmake.cfg
@@ -2,18 +2,18 @@
 name: example
 
 [fc]
-source: https://github.com/miroi/autocmake/raw/master/modules/fc.cmake
+source: https://github.com/scisoft/autocmake/raw/master/modules/fc.cmake
 docopt: --fc=<FC> Fortran compiler [default: gfortran].
         --extra-fc-flags=<EXTRA_FCFLAGS> Extra Fortran compiler flags [default: ''].
 define: ' FC=%s' % arguments['--fc']
         '-DEXTRA_FCFLAGS="%s"' % arguments['--extra-fc-flags']
 
 [compilers]
-source: https://github.com/miroi/autocmake/raw/master/compilers/GNU.Fortran.cmake
+source: https://github.com/scisoft/autocmake/raw/master/compilers/GNU.Fortran.cmake
 
 [default_build_paths]
-source: https://github.com/miroi/autocmake/raw/master/modules/default_build_paths.cmake
+source: https://github.com/scisoft/autocmake/raw/master/modules/default_build_paths.cmake
 
 [src]
-source: https://github.com/miroi/autocmake/raw/master/modules/src.cmake
+source: https://github.com/scisoft/autocmake/raw/master/modules/src.cmake
 

--- a/test/fc/cmake/autocmake.cfg
+++ b/test/fc/cmake/autocmake.cfg
@@ -2,17 +2,18 @@
 name: example
 
 [fc]
-source: https://github.com/scisoft/autocmake/raw/master/modules/fc.cmake
+source: https://github.com/miroi/autocmake/raw/master/modules/fc.cmake
 docopt: --fc=<FC> Fortran compiler [default: gfortran].
         --extra-fc-flags=<EXTRA_FCFLAGS> Extra Fortran compiler flags [default: ''].
-export: 'FC=%s' % arguments['--fc']
-define: '-DEXTRA_FCFLAGS="%s"' % arguments['--extra-fc-flags']
+define: ' FC=%s' % arguments['--fc']
+        '-DEXTRA_FCFLAGS="%s"' % arguments['--extra-fc-flags']
 
 [compilers]
-source: https://github.com/scisoft/autocmake/raw/master/compilers/GNU.Fortran.cmake
+source: https://github.com/miroi/autocmake/raw/master/compilers/GNU.Fortran.cmake
 
 [default_build_paths]
-source: https://github.com/scisoft/autocmake/raw/master/modules/default_build_paths.cmake
+source: https://github.com/miroi/autocmake/raw/master/modules/default_build_paths.cmake
 
 [src]
-source: https://github.com/scisoft/autocmake/raw/master/modules/src.cmake
+source: https://github.com/miroi/autocmake/raw/master/modules/src.cmake
+

--- a/test/test.py
+++ b/test/test.py
@@ -1,12 +1,14 @@
 import os
+import sys
 import subprocess
+import shlex
 import update
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def exe(command):
-    stdout, stderr = subprocess.Popen(command.split(),
+    stdout, stderr = subprocess.Popen(shlex.split(command),
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE).communicate()
     return stdout, stderr
@@ -18,10 +20,17 @@ def test_cxx():
     stdout, stderr = exe('python update.py --self')
     stdout, stderr = exe('python update.py ..')
     os.chdir(os.path.join(HERE, 'cxx'))
-    stdout, stderr = exe('python setup.py --cxx=g++')
+    if sys.platform == 'win32':
+        stdout, stderr = exe('python setup.py --cxx=g++ --generator="MinGW Makefiles" ')
+    else:
+        stdout, stderr = exe('python setup.py --cxx=g++')
     os.chdir(os.path.join(HERE, 'cxx', 'build'))
-    stdout, stderr = exe('make')
-    stdout, stderr = exe('./bin/example')
+    if sys.platform == 'win32':
+        stdout, stderr = exe('mingw32-make')
+        stdout, stderr = exe('bin\\\example.exe')
+    else:
+        stdout, stderr = exe('make')
+        stdout, stderr = exe('./bin/example')
     assert 'Hello World!' in stdout
 
 
@@ -31,8 +40,15 @@ def test_fc():
     stdout, stderr = exe('python update.py --self')
     stdout, stderr = exe('python update.py ..')
     os.chdir(os.path.join(HERE, 'fc'))
-    stdout, stderr = exe('python setup.py --fc=gfortran')
+    if sys.platform == 'win32':
+        stdout, stderr = exe('python setup.py --fc=gfortran --generator="MinGW Makefiles"')
+    else:
+        stdout, stderr = exe('python setup.py --fc=gfortran')
     os.chdir(os.path.join(HERE, 'fc', 'build'))
-    stdout, stderr = exe('make')
-    stdout, stderr = exe('./bin/example')
+    if sys.platform == 'win32':
+        stdout, stderr = exe("mingw32-make")
+        stdout, stderr = exe('bin\\\example.exe')
+    else:
+        stdout, stderr = exe('make')
+        stdout, stderr = exe('./bin/example')
     assert 'Hello World!' in stdout

--- a/update.py
+++ b/update.py
@@ -92,6 +92,7 @@ def gen_cmake_command(config):
                 s.append('    command.append(%s)' % definition)
 
     s.append("    command.append('-DCMAKE_BUILD_TYPE=%s' % arguments['--type'])")
+    s.append("    command.append('-G \"%s\"' % arguments['--generator'])")
 
     s.append("\n    return ' '.join(command)")
 
@@ -129,6 +130,7 @@ def gen_setup(config, relative_path):
                 options.append([first, rest])
 
     options.append(['--type=<TYPE>', 'Set the CMake build type (debug, release, or relwithdeb) [default: release].'])
+    options.append(['--generator=<STRING>', 'Set the CMake build system generator [default: Unix Makefiles].'])
     options.append(['--show', 'Show CMake command and exit.'])
     options.append(['<builddir>', 'Build directory.'])
     options.append(['-h --help', 'Show this screen.'])
@@ -181,8 +183,11 @@ def gen_cmakelists(config, relative_path, list_of_modules):
 
     s.append('\n# directory which holds enabled cmake modules')
     s.append('set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}')
-    s.append('    ${PROJECT_SOURCE_DIR}/%s)' % os.path.join(relative_path, 'modules'))
-
+    if sys.platform == 'win32':
+        # miro: keep the same path separator on Windows
+        s.append('    ${PROJECT_SOURCE_DIR}/%s' % relative_path + "/modules)")
+    else:
+        s.append('    ${PROJECT_SOURCE_DIR}/%s)' % os.path.join(relative_path, 'modules'))
     s.append('\n# included cmake modules')
     for m in list_of_modules:
         s.append('include(autocmake_%s)' % os.path.splitext(m)[0])


### PR DESCRIPTION
Adapt the autocmake project for MS Windows. Needs to adapt README.md wrt to the appveyor-CI service.

list of squashed commits:
------------------------------------
added (setup.py) flag for CMake build system generators
available generators are listed upon "cmake --help"
modified for MinGW suite on MS Windows
added buildup script  for CI service appveyor (first try)
next try
added appveyor badge
better form
better layout
added pytest installation, according to Ivan's advice
extended Python path - added py-scripts
added Ivan's changes
ihrasko: update appveyor testing
ihrasko: update appveyor testing
ihrasko: update appveyor testing
ihrasko: update appveyor testing
returned back to Radovan's README.md; travis-ci/appveryor will be
checked on the web
remove empty line - maybe this help to fix travis-ci check
remove line with the generator (hoping to fix travis-ci tests)
remove line with generator (to satisfy travic-ci)
ihrasko: install mingw-w64 version 4.9.2
if you want newer version, please change url
getting "--generator" inside as stup.py's core flag
point to my update.py script
fix path for Windows
fix of path separator on Windows
update - fix of path separator in path
update
upd
fixed for MS Windows
pinting to my sources
upd
iadapt
upd
fix for Win
fix
appveyor, own travis-ci added
upd
upd
fix
upd
setup.py works on WIndows, running executable not
polish; still not executing the compiled executable
polish
tests are working on Windows!
provide default for generator (Unix Makefiles)
try to fix generator
fix default CMake generator
added path for "import update" - own module
fix of PYTHONPATH
try to fix appveyor buildup - python setup command not working !
fix update - must point to my fork !
polish according to pep8
fix according to pep8
prepare for merge