### PR TITLE
Adapted lib/config.py for MS Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 [![Build Status](https://travis-ci.org/scisoft/autocmake.svg?branch=master)](https://travis-ci.org/scisoft/autocmake/builds)
 [![Documentation Status](https://readthedocs.org/projects/autocmake/badge/?version=latest)](http://autocmake.readthedocs.org)
-
-MiroI build statuses:
-[![Build Status](https://travis-ci.org/miroi/autocmake.svg?branch=master)](https://travis-ci.org/miroi/autocmake/builds)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/miroi/autocmake?branch=master&svg=true)](https://ci.appveyor.com/project/miroi/autocmake)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/scisoft/autocmake?branch=appveyor&svg=true)](https://ci.appveyor.com/project/scisoft/autocmake)
 
 
 # Autocmake

--- a/lib/config.py
+++ b/lib/config.py
@@ -47,29 +47,20 @@ def adapt_cmake_command_to_arch(cmake_command):
     """
     Adapt CMake command for MS Windows architecture:
 
-      "FC=foo CC=bar cmake -DTHIS -DTHAT='this and that'" rewrites into
+ "FC=foo CC=bar cmake -DTHIS -DTHAT='this and that'" rewrites into
 
-      "set FC=foo && set CC=bar && cmake -DTHIS -DTHAT='this and that'"
+ "set FC=foo && set CC=bar && cmake -DTHIS -DTHAT='this and that'"
     """
 
     if sys.platform == 'win32':
         cmake_pos=cmake_command.find('cmake')
         cmake_export_vars=cmake_command[:cmake_pos]
         cmake_strings=cmake_command[cmake_pos:]
-        print "\n strings from cmake to right:",cmake_strings
-        print "strings from left up to cmake:",cmake_export_vars
-        print "strings from left up to cmake, split:",cmake_export_vars.split()
         all_modified_exported_vars=""
         for exported_var in cmake_export_vars.split():
-            print "exported_var=",exported_var
             modified_exported_var="set " + exported_var + " && "
             all_modified_exported_vars=all_modified_exported_vars+modified_exported_var
-        print "all_modified_exported_vars=",all_modified_exported_vars
-        cmake_command_win=all_modified_exported_vars+cmake_strings
-        print "cmake_command_win=",cmake_command_win
-        print "\n"
-        #sys.exit(-1)
-        cmake_command_arch = cmake_command_win
+        cmake_command_arch = all_modified_exported_vars + cmake_strings
     else:
         cmake_command_arch = cmake_command
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -43,6 +43,38 @@ def setup_build_path(build_path):
     else:
         os.makedirs(build_path, 0o755)
 
+def adapt_cmake_command_to_arch(cmake_command):
+    """
+    Adapt CMake command for MS Windows architecture:
+
+      "FC=foo CC=bar cmake -DTHIS -DTHAT='this and that'" rewrites into
+
+      "set FC=foo && set CC=bar && cmake -DTHIS -DTHAT='this and that'"
+    """
+
+    if sys.platform == 'win32':
+        cmake_pos=cmake_command.find('cmake')
+        cmake_export_vars=cmake_command[:cmake_pos]
+        cmake_strings=cmake_command[cmake_pos:]
+        print "\n strings from cmake to right:",cmake_strings
+        print "strings from left up to cmake:",cmake_export_vars
+        print "strings from left up to cmake, split:",cmake_export_vars.split()
+        all_modified_exported_vars=""
+        for exported_var in cmake_export_vars.split():
+            print "exported_var=",exported_var
+            modified_exported_var="set " + exported_var + " && "
+            all_modified_exported_vars=all_modified_exported_vars+modified_exported_var
+        print "all_modified_exported_vars=",all_modified_exported_vars
+        cmake_command_win=all_modified_exported_vars+cmake_strings
+        print "cmake_command_win=",cmake_command_win
+        print "\n"
+        #sys.exit(-1)
+        cmake_command_arch = cmake_command_win
+    else:
+        cmake_command_arch = cmake_command
+
+    return cmake_command_arch
+
 
 def run_cmake(command, build_path, default_build_path):
     """
@@ -114,6 +146,8 @@ def configure(root_directory, build_path, cmake_command, only_show):
         build_path = default_build_path
     if not only_show:
         setup_build_path(build_path)
+
+    cmake_command=adapt_cmake_command_to_arch(cmake_command)
 
     print('%s\n' % cmake_command)
     if only_show:


### PR DESCRIPTION
New function in lib/config.py does preprocessing of the cmake_command for MS Windows according to Radovan's suggestion.

CI tests are OK: 
https://ci.appveyor.com/project/miroi/autocmake
https://travis-ci.org/miroi/autocmake