### PR TITLE
ihrasko: improved test script for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,60 @@
+##
+# The autocmake project test configuration for Windows OS at AppVeyor
+# 
+# Current software used:
+# OS: 64-bit Windows Server 2012 R2
+# Compilers: 64-bit MinGw-w64 5.1.0 (downloaded during script execution)
+# Python: 2.7, both 32-bit and 64-bit versions
+#
+# Notes:
+# Can be extended for use with Python 3
+# Where "ps:" is used commands are executed in PowerShell
+##
+
+# build version format: 1.0.1, 1.0.2, ...
 version: 1.0.{build}
-init:
-- ps: >-
-    mkdir C:\software
 
-    cd C:\software
-
-    wget http://netcologne.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-posix/seh/x86_64-4.9.2-release-posix-seh-rt_v4-rev2.7z -OutFile MinGW.7z
-
-    7z x MinGW.7z > log_mingw.txt
-
-    wget https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-
-    python get-pip.py
-
-    pip install pytest
-
-    cd C:\projects\autocmake
+# prepare environment
 environment:
-  path: C:\Perl\site\bin;C:\Perl\bin;C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files (x86)\Mercurial;C:\Program Files\7-Zip;C:\Progr am Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\Microsoft SQL Server\110\Tools\Binn\;C:\Program Files (x86)\Microsoft ASP.NET\ASP.NET Web Pages \v1.0\;C:\Program Files (x86)\Microsoft SDKs\Windows Azure\CLI\wbin;C:\Program Files (x86)\MSBuild\12.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Tools\xUnit;C:\T ools\NUnit\bin;C:\Tools\NuGet;C:\Python27;C:\Python27\Scripts;C:\Program Files (x86)\Microsoft SQL Server\100\Tools\Binn\;C:\Program Files\Microsoft SQL Server\100\Tools\Binn\;C:\Program Files\Microsoft SQL Server\100\DTS\Binn\;C:\Program Files (x86 )\Microsoft SQL Server\100\Tools\Binn\VSShell\Common7\IDE\;C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\IDE\PrivateAssemblies\;C:\Program Files (x86)\Microsoft SQL Server\100\DTS\Binn\;C:\Program Files (x86)\Microso ft SQL Server\110\Tools\Binn\;C:\Program Files\Microsoft SQL Server\110\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\110\Tools\Binn\ManagementStudio\;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE\Privat eAssemblies\;C:\Program Files (x86)\Microsoft SQL Server\110\DTS\Binn\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\110\Tools\Binn\;C:\Program Files (x86)\Microsoft S QL Server\120\Tools\Binn\;C:\Program Files\Microsoft SQL Server\120\DTS\Binn\;C:\Program Files (x86)\Microsoft SQL Server\120\Tools\Binn\ManagementStudio\;C:\Program Files (x86)\Microsoft SQL Server\120\DTS\Binn\;C:\Tools\WebDriv er;C:\Program Files\Microsoft\Web Platform Installer\;C:\Tools\MSpec;C:\Program Files\nodejs;C:\Program Files (x86)\nodejs;C:\Program Files\Java\jdk1.7.0\bin;C:\ProgramData\chocolatey\bin;C:\Tools\GitVersion;C:\Program Files (x86 )\Microsoft Fxcop 10.0;C:\Program Files (x86)\Git\cmd;C:\Program Files (x86)\CollabNet\Subversion Client;C:\Program Files (x86)\iojs;C:\Program Files\iojs;C:\Users\appveyor\AppData\Roaming\npm;C:\Pr ogram Files (x86)\Microsoft SDKs\TypeScript\1.4\;C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.0\;C:\Ruby193\bin;C:\Program Files (x86)\CMake\bin;C:\go\bin;C:\Tools\Coverity\bin;C:\Program Files\erl6.3\bin;C:\Chocolatey\bin;C:\Program Files\AppVeyor\BuildAgent;C:\software\mingw64\bin
+# set custom path (will be more extended later in build_script section)
+  path: C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files (x86)\Git\cmd;C:\Program Files\7-Zip;C:\Program Files (x86)\CMake\bin
+# set MinGw-w64 (64-bit) version 5.1.0 download URL
+  url: http://kent.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/5.1.0/threads-posix/seh/x86_64-5.1.0-release-posix-seh-rt_v4-rev0.7z
+# user can possibly use different Python versions, we try to test multiple cases
+# 64-bit version is recommended
+  matrix:
+# Python 2.7; 32-bit version
+    - python: C:\Python27;C:\Python27\Scripts
+# Python 2.7; 64-bit version
+    - python: C:\Python27-x64;C:\Python27-x64\Scripts
+
 build_script:
-- set PYTHONPATH=%PYTHONPATH%;%cd%
-- py.test test/test.py
+# add location of used Python to path
+- set path=%path%;%python%
+
+# create dir for custom software and move there
+- mkdir C:\software && cd C:\software
+
+# download and unpack MinGw-w64 compilers
+- ps: wget $env:url -OutFile MinGW.7z
+- 7z x MinGW.7z > NUL
+
+# add compilers binary dir to path
+- set path=%path%;C:\software\mingw64\bin
+
+# download and upgrade pip
+- ps: wget https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+- python get-pip.py
+
+# install py.test
+- pip install pytest
+
+# go back to project source dir
+- cd C:\projects\autocmake
+
+test_script:
+# show environment
+- echo %path%
+- py.test --version
+# run tests
+- py.test -v test/test.py


### PR DESCRIPTION
using shorter path
testing both 32-bit and 64-bit Python versions
downloading and using the latest 5.1.0 version of mingw-w64 compilers
added comments

***
Script is run on 64-bit Windows OS. In that case it is good to use 64-bit compilers. Then it is possible to compile Dirac with and also without 64-bit integers on without problems. During execution 64-bit Mingw-w64 compilers are downloaded.

In script both 32 and 64-bit versions of Python are used (every commit runs two tests, see picture).
But still it is "better" to use 64-bit Python.
Reasons:
1. I have not tested 32-bit Python with Dirac on 64-bit Windows for long time
(but it should work, 32-bit Python on 32-bit Windows works good)
2. It is possible to follow instructions from Dirac documentation to install packages needed to generate documentation - mingw32-make html ... 

It is possible to use also Python 3, because it is already preinstalled at AppVeyor.
But it looks autocmake is not adapted for Python 3.
***
![test](https://cloud.githubusercontent.com/assets/9216891/8513446/ddb2dd80-236b-11e5-95c3-40ba5d4d6a16.png)
