### PR TITLE
adaptation of test for Python 3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ build_script:
 - pip install pytest
 
 # go back to project source dir
-- cd C:\projects\autocmake
+- cd %APPVEYOR_BUILD_FOLDER%
 
 test_script:
 # show environment

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@
 # OS: 64-bit Windows Server 2012 R2
 # Compilers: 64-bit MinGw-w64 5.1.0 (downloaded during script execution)
 # Python: 2.7, both 32-bit and 64-bit versions
+# Python: 3.4, both 32-bit and 64-bit versions
 #
 # Notes:
-# Can be extended for use with Python 3
 # Where "ps:" is used commands are executed in PowerShell
 ##
 
@@ -21,12 +21,17 @@ environment:
 # set MinGw-w64 (64-bit) version 5.1.0 download URL
   url: http://kent.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/5.1.0/threads-posix/seh/x86_64-5.1.0-release-posix-seh-rt_v4-rev0.7z
 # user can possibly use different Python versions, we try to test multiple cases
-# 64-bit version is recommended
+# 64-bit version on 64-bit system allows easier installation of Python packages using .exe installers
+# and better CMake automatic detection of some Python tools
   matrix:
 # Python 2.7; 32-bit version
     - python: C:\Python27;C:\Python27\Scripts
 # Python 2.7; 64-bit version
     - python: C:\Python27-x64;C:\Python27-x64\Scripts
+# Python 3.4; 32-bit version
+    - python: C:\Python34;C:\Python34\Scripts
+# Python 3.4; 64-bit version
+    - python: C:\Python34-x64;C:\Python34-x64\Scripts
 
 build_script:
 # add location of used Python to path

--- a/test/test.py
+++ b/test/test.py
@@ -46,9 +46,22 @@ def fetch_url(src, dst):
 
 
 def exe(command):
+    """
+    Executes command and returns string representations of stdout and stderr captured from the console.
+    When universal_newlines=True stdout and stderr are opened in text mode.
+    Otherwise, they are opened in binary mode. In that case captured stdout and stderr
+    are not strings and Python 3 throws type error when compared against strings later in tests.
+ 
+    Note:
+    This feature is only available if Python is built with universal newline support (the default).
+    Also, the newlines attribute of the file objects stdout, stdin and stderr are not updated by the
+    communicate() method.
+    See https://docs.python.org/2/library/subprocess.html
+    """
     stdout, stderr = subprocess.Popen(shlex.split(command),
                                       stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE).communicate()
+                                      stderr=subprocess.PIPE,
+                                      universal_newlines=True).communicate()
     return stdout, stderr
 
 # ------------------------------------------------------------------------------

--- a/test/test.py
+++ b/test/test.py
@@ -51,7 +51,6 @@ def exe(command):
     When universal_newlines=True stdout and stderr are opened in text mode.
     Otherwise, they are opened in binary mode. In that case captured stdout and stderr
     are not strings and Python 3 throws type error when compared against strings later in tests.
- 
     Note:
     This feature is only available if Python is built with universal newline support (the default).
     Also, the newlines attribute of the file objects stdout, stdin and stderr are not updated by the


### PR DESCRIPTION
Avoid type errors with Python 3 during tests by opening stdout and stderr in text mode.
Add testing with Python 3 to AppVeyor testing script (+ comments and little improvement).