### PR TITLE
add test to appveyor, adapt build info, docs update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,3 +63,4 @@ test_script:
 - py.test --version
 # run tests
 - py.test -v test/test.py
+- py.test -v lib/config.py

--- a/doc/new-project.rst
+++ b/doc/new-project.rst
@@ -8,13 +8,21 @@ Bootstrapping Autocmake
 -----------------------
 
 Download the ``update.py`` and execute it to fetch other infrastructure files
-which will be needed to build the project (on Windows ``wget`` is probably
-not available - in this case use an alternative)::
+which will be needed to build the project. Example on Linux::
 
   mkdir cmake  # does not have to be called "cmake" - take the name you prefer
   cd cmake
   wget https://github.com/scisoft/autocmake/raw/master/update.py
   python update.py --self
+
+Example on Windows using tools installed with Git::
+
+  mkdir cmake  # does not have to be called "cmake" - take the name you prefer
+  cd cmake
+  C:\Program Files (x86)\Git\bin\curl.exe -o update.py -L https://github.com/scisoft/autocmake/raw/master/update.py
+  python update.py --self
+
+Do not add ``...Git\bin...`` to PATH. Otherwise you will experience conflicts with CMake.
 
 This creates (or updates) the following files (an existing ``autocmake.cfg`` is
 not overwritten by the script)::
@@ -58,4 +66,4 @@ the project::
   cd ..
   python setup.py [-h]
   cd build
-  make
+  make # or mingw32-make on Windows

--- a/lib/config.py
+++ b/lib/config.py
@@ -94,7 +94,7 @@ def run_cmake(command, build_path, default_build_path):
     if 'Configuring incomplete' in s:
         # configuration was not successful
         if (build_path == default_build_path):
-            # remove build_path iff not set by the user
+            # remove build_path if not set by the user
             # otherwise removal can be dangerous
             shutil.rmtree(default_build_path)
     else:
@@ -113,7 +113,10 @@ def print_build_help(build_path, default_build_path):
         print('   $ cd build')
     else:
         print('   $ cd ' + build_path)
-    print('   $ make')
+    if sys.platform == 'win32':
+        print('   $ mingw32-make')
+    else:
+        print('   $ make')
 
 
 def save_configure_command(argv, build_path):


### PR DESCRIPTION
Added test in lib/config.py to testing at AppVeyor.
Adapted build info for Windows and MinGW compilers - use mingw32-make.
Added example to docs how to download update.py file on Windows with Git tools.