### PR TITLE
Allow fc_omp test on MS Windows

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -164,7 +164,6 @@ def test_fc_mpi():
 # ------------------------------------------------------------------------------
 
 
-@skip_on_windows
 def test_fc_omp():
     os.environ['OMP_NUM_THREADS'] = '2'
     configure_build_and_exe('fc_omp', 'python setup.py --omp --fc=gfortran')


### PR DESCRIPTION
This should work as the MinGW Fortran supports the OpenMP parallelization.