### PR TITLE
WIP: adapt fc_mpi test for MS Windows by utilizing ms-mpi package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,10 +50,24 @@ build_script:
 # download and unpack the  OpenBLAS library, integer*4 (or i32lp64) version
 - ps: wget http://skylink.dl.sourceforge.net/project/openblas/v0.2.14/OpenBLAS-v0.2.14-Win64-int32.zip -OutFile OpenBLAS-v0.2.14-Win64-int32.zip
 - 7z x OpenBLAS-v0.2.14-Win64-int32.zip > NUL
-
+#
 # add both OpenBLAS dynamic (libopenblas.dll) and static (libopenblas.a) library files dir to path
 - set path=%path%;C:\software\OpenBLAS-v0.2.14-Win64-int32\bin;C:\software\OpenBLAS-v0.2.14-Win64-int32\lib
 
+# download and unpack MSMPI library (Windows version of OpenMPI)
+# follow http://www.symscape.com/configure-msmpi-for-mingw-w64#comment-1824
+- mkdir C:\software\msmpi && cd C:\software\msmpi
+- ps: wget http://download.microsoft.com/download/A/1/3/A1397A8C-4751-433C-8330-F738C3BE2187/mpi_x64.Msi -OutFile mpi_x64.Msi
+- 7z x mpi_x64.Msi
+- gendef msmpi64.dll
+- dlltool -d msmpi64.def -l libmsmpi64.a -D msmpi64.dll
+- del mpi.f90
+- ps: wget http://web-docs.gsi.de/~milias/msmpi/mpi.F90 -OutFile mpi.F90
+- gfortran  -c  -D_WIN64  -D INT_PTR_KIND()=8 -fno-range-check   mpi.F90
+- dir
+
+# add msmpi to path
+- set path=%path%;C:\software\msmpi
 
 # download and upgrade pip
 - ps: wget https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py

--- a/test/fc_mpi/src/CMakeLists.txt
+++ b/test/fc_mpi/src/CMakeLists.txt
@@ -1,5 +1,10 @@
 if (MPI_FOUND)
     add_executable(example example.f90)
+    if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+        # path in appveyor.yml
+        #target_link_libraries(example "C:\software\msmpi\libmsmpi64.a")
+        target_link_libraries(example "C:/software/msmpi/libmsmpi64.a")
+    endif()
 else()
     message(FATAL "MPI not found!")
 endif()

--- a/test/test.py
+++ b/test/test.py
@@ -157,9 +157,11 @@ def test_fc_int64():
 # ------------------------------------------------------------------------------
 
 
-@skip_on_windows
 def test_fc_mpi():
-    configure_build_and_exe('fc_mpi', 'python setup.py --mpi --fc=mpif90', 'mpirun -np 2')
+    if sys.platform == 'win32':
+        configure_build_and_exe('fc_mpi', 'python setup.py --mpi --fc=gfortran', 'mpiexec -n 2')
+    else:
+        configure_build_and_exe('fc_mpi', 'python setup.py --mpi --fc=mpif90', 'mpirun -np 2')
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
By applying https://github.com/scisoft/autocmake/issues/85  I adapted fc_mpi test for MS Windows. 

I am asking for the code review. For example, I prepared my own *mpi.F90* and appveyor.yml is downloading it from my private URL.

Likewise the *test/fc_mpi/src/CMakeLists.txt* can be rewritten in smarter style to search for the *libmsmpi64.a* library.