### PR TITLE
Tweak the fc_mpi test to use both the MPI module file and the MPI include file

### DIFF
--- a/test/fc_mpi/src/CMakeLists.txt
+++ b/test/fc_mpi/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (MPI_FOUND)
-    add_executable(example example.f90)
+    add_executable(example example.F90)
 else()
     message(FATAL "MPI not found!")
 endif()

--- a/test/fc_mpi/src/example.F90
+++ b/test/fc_mpi/src/example.F90
@@ -1,8 +1,12 @@
 program example
 
+#if defined USE_MPI_MODULE
    use mpi
-
    implicit none
+#else
+   implicit none
+#include "mpif.h"
+#endif
 
    integer :: ierr, rank, num_ranks
    logical :: test_ok

--- a/test/test.py
+++ b/test/test.py
@@ -158,7 +158,12 @@ def test_fc_int64():
 
 
 @skip_on_windows
-def test_fc_mpi():
+def test_fc_mpi_module():
+    configure_build_and_exe('fc_mpi', 'python setup.py --mpi --fc=mpif90  --extra-fc-flags="-D USE_MPI_MODULE"', 'mpirun -np 2')
+
+
+@skip_on_windows
+def test_fc_mpi_include():
     configure_build_and_exe('fc_mpi', 'python setup.py --mpi --fc=mpif90', 'mpirun -np 2')
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
We need to check  the simple Fortran90 mpi-testing program both for using the "modern" mpi Fortran90 module and the "classic" mpif.h include file.

Later, this test is planned to be adjusted for the MS-MPI implementation, where one needs to verify/adapt both the module file, *mpi.F90*, and the include file, *mpif.h* on the MS Windows platform (see https://github.com/scisoft/autocmake/issues/85).