### PR TITLE
Python interpreter and libraries detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,29 @@
+sudo: false
 language: cpp
-install:
-    # update, clean
-  - sudo apt-get update
-  - sudo apt-get clean
-  - sudo apt-get autoclean
-    # compilers
-  - sudo apt-get install g++ cmake gfortran
-    # libraries for static linking
-  - sudo apt-get install binutils-gold libc6-dev libpthread-stubs0-dev
-    # math libraries
-  - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev
-    # MPI
-  - sudo apt-get install openmpi-bin libopenmpi-dev
+addons:
+  apt:
+    packages:
+       # Compilers
+      - g++
+      - gfortran
+      - cmake
+        # Libraries for static linking
+      - binutils-gold
+      - libc6-dev
+      - libpthread-stubs0-dev
+        # Math libraries
+      - libblas-dev
+      - liblapack-dev
+      - libatlas-base-dev
+        # MPI
+      - openmpi-bin
+      - libopenmpi-dev
+        # Python library, development version
+      - libpython2.7
+before_script:
+  - export PATH=$HOME/.local/bin:$PATH
     # PEP8 and py.test
-  - sudo pip install pytest pep8
+  - pip install pytest pep8 --user `whoami`
 script:
     # test PEP8 conformity
   - pep8 --ignore=E501 update.py

--- a/modules/python.cmake
+++ b/modules/python.cmake
@@ -1,9 +1,0 @@
-#.rst:
-#
-# Detects Python interpreter.
-#
-# Variables defined::
-#
-#   PYTHON_EXECUTABLE
-
-find_package(PythonInterp REQUIRED)

--- a/modules/python_interpreter.cmake
+++ b/modules/python_interpreter.cmake
@@ -1,0 +1,36 @@
+#.rst:
+#
+# Detects Python interpreter.
+#
+# Variables used::
+#
+#   PYTHON_INTERPRETER         - User-set path to the Python interpreter
+#
+# Variables defined::
+#
+#   PYTHONINTERP_FOUND         - Was the Python executable found
+#   PYTHON_EXECUTABLE          - path to the Python interpreter
+#   PYTHON_VERSION_STRING      - Python version found e.g. 2.5.2
+#   PYTHON_VERSION_MAJOR       - Python major version found e.g. 2
+#   PYTHON_VERSION_MINOR       - Python minor version found e.g. 5
+#   PYTHON_VERSION_PATCH       - Python patch version found e.g. 2
+#
+# autocmake.cfg configuration::
+#
+#   docopt: --python=<PYTHON_INTERPRETER> The Python interpreter (development version) to use. [default: ''].
+#   define: '-DPYTHON_INTERPRETER="%s"' % arguments['--python']
+
+if("${PYTHON_INTERPRETER}" STREQUAL "")
+    find_package(PythonInterp REQUIRED)
+else()
+    if(NOT EXISTS "${PYTHON_INTERPRETER}")
+        find_program(PYTHON_EXECUTABLE NAMES ${PYTHON_INTERPRETER})
+        if (NOT EXISTS "${PYTHON_EXECUTABLE}")
+            set(PYTHONINTERP_FOUND FALSE)
+        endif()
+    else()
+        set(PYTHONINTERP_FOUND TRUE)
+        set(PYTHON_EXECUTABLE "${PYTHON_INTERPRETER}")
+    endif()
+endif()
+find_package(PythonInterp REQUIRED)

--- a/modules/python_libs.cmake
+++ b/modules/python_libs.cmake
@@ -1,0 +1,85 @@
+#.rst:
+#
+# Detects Python libraries and headers.
+# Detection is done basically by hand as the proper CMake package
+# will not find libraries and headers matching the interpreter version.
+#
+# Dependencies::
+#   python_interpreter         - Sets the Python interpreter for headers and libraries detection
+#
+# Variables used::
+#
+#   PYTHONINTERP_FOUND         - Was the Python executable found
+#
+# Variables defined::
+#
+#   PYTHONLIBS_FOUND           - have the Python libs been found
+#   PYTHON_LIBRARIES           - path to the python library
+#   PYTHON_INCLUDE_DIRS        - path to where Python.h is found
+#   PYTHONLIBS_VERSION_STRING  - version of the Python libs found (since CMake 2.8.8)
+
+if(PYTHONINTERP_FOUND)
+   # Get Python include path from Python interpreter
+   execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+                         "import distutils.sysconfig, sys; sys.stdout.write(distutils.sysconfig.get_python_inc())"
+                  OUTPUT_VARIABLE _PYTHON_INCLUDE_PATH
+                  RESULT_VARIABLE _PYTHON_INCLUDE_RESULT)
+   # Get Python library path from interpreter
+   execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+                        "from distutils.sysconfig import get_config_var; import sys; sys.stdout.write(get_config_var('LIBDIR'))"
+                  OUTPUT_VARIABLE _PYTHON_LIB_PATH
+                  RESULT_VARIABLE _PYTHON_LIB_RESULT)
+
+   set(PYTHON_INCLUDE_DIR ${_PYTHON_INCLUDE_PATH} CACHE PATH "Path to a directory")
+   set(_PYTHON_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+   set(_PYTHON_VERSION_NO_DOTS "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+
+   find_library(PYTHON_LIBRARY
+     NAMES
+     python${_PYTHON_VERSION_NO_DOTS}
+     python${_PYTHON_VERSION}mu
+     python${_PYTHON_VERSION}m
+     python${_PYTHON_VERSION}u
+     python${_PYTHON_VERSION}
+     NO_DEFAULT_PATH
+     HINTS
+     "${_PYTHON_LIB_PATH}"
+     DOC "Path to Python library file."
+   )
+   if (NOT EXISTS "${PYTHON_LIBRARY}")
+       # redo with default paths
+       find_library(PYTHON_LIBRARY
+         NAMES
+         python${_PYTHON_VERSION_NO_DOTS}
+         python${_PYTHON_VERSION}mu
+         python${_PYTHON_VERSION}m
+         python${_PYTHON_VERSION}u
+         python${_PYTHON_VERSION}
+         HINTS
+         "${_PYTHON_LIB_PATH}"
+         DOC "Path to Python library file."
+       )
+   endif()
+
+   mark_as_advanced(CLEAR PYTHON_EXECUTABLE)
+   mark_as_advanced(FORCE PYTHON_LIBRARY)
+   mark_as_advanced(FORCE PYTHON_INCLUDE_DIR)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PythonLibs
+    REQUIRED_VARS
+    PYTHON_LIBRARY
+    PYTHON_INCLUDE_DIR
+    PYTHON_EXECUTABLE)
+
+if(NOT PYTHONLIBS_FOUND)
+    message(FATAL_ERROR "Could NOT find PythonLibs")
+endif()
+
+# Hook-up script variables to cache variables
+set(PYTHON_LIBRARIES ${PYTHON_LIBRARY})
+set(PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIR})
+
+include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
+link_directories(${PYTHON_LIBRARIES})

--- a/test/python_interpreter/cmake/autocmake.cfg
+++ b/test/python_interpreter/cmake/autocmake.cfg
@@ -1,0 +1,14 @@
+[project]
+name: example
+
+[cxx]
+source: ../../../modules/cxx.cmake
+
+[python_interpreter]
+source: ../../../modules/python_interpreter.cmake
+
+[default_build_paths]
+source: ../../../modules/default_build_paths.cmake
+
+[src]
+source: ../../../modules/src.cmake

--- a/test/python_interpreter/src/CMakeLists.txt
+++ b/test/python_interpreter/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(example example.cpp)

--- a/test/python_interpreter/src/example.cpp
+++ b/test/python_interpreter/src/example.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "PASSED";
+    return 0;
+}

--- a/test/python_interpreter_custom/cmake/autocmake.cfg
+++ b/test/python_interpreter_custom/cmake/autocmake.cfg
@@ -1,0 +1,14 @@
+[project]
+name: example
+
+[cxx]
+source: ../../../modules/cxx.cmake
+
+[python_interpreter]
+source: ../../../modules/python_interpreter.cmake
+
+[default_build_paths]
+source: ../../../modules/default_build_paths.cmake
+
+[src]
+source: ../../../modules/src.cmake

--- a/test/python_interpreter_custom/src/CMakeLists.txt
+++ b/test/python_interpreter_custom/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(example example.cpp)

--- a/test/python_interpreter_custom/src/example.cpp
+++ b/test/python_interpreter_custom/src/example.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "PASSED";
+    return 0;
+}

--- a/test/python_libs/cmake/autocmake.cfg
+++ b/test/python_libs/cmake/autocmake.cfg
@@ -1,0 +1,17 @@
+[project]
+name: example
+
+[cxx]
+source: ../../../modules/cxx.cmake
+
+[python_interpreter]
+source: ../../../modules/python_interpreter.cmake
+
+[python_libs]
+source: ../../../modules/python_libs.cmake
+
+[default_build_paths]
+source: ../../../modules/default_build_paths.cmake
+
+[src]
+source: ../../../modules/src.cmake

--- a/test/python_libs/src/CMakeLists.txt
+++ b/test/python_libs/src/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(example example.cpp)
+target_link_libraries(example ${PYTHON_LIBRARIES})

--- a/test/python_libs/src/example.cpp
+++ b/test/python_libs/src/example.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <Python.h>
+
+int main(int argc, char *argv[])
+{
+    Py_SetProgramName(argv[0]);  /* optional but recommended */
+    Py_Initialize();
+    PyRun_SimpleString("print('PASSED')\n");
+    Py_Finalize();
+    return 0;
+}

--- a/test/python_libs_custom/cmake/autocmake.cfg
+++ b/test/python_libs_custom/cmake/autocmake.cfg
@@ -1,0 +1,17 @@
+[project]
+name: example
+
+[cxx]
+source: ../../../modules/cxx.cmake
+
+[python_interpreter]
+source: ../../../modules/python_interpreter.cmake
+
+[python_libs]
+source: ../../../modules/python_libs.cmake
+
+[default_build_paths]
+source: ../../../modules/default_build_paths.cmake
+
+[src]
+source: ../../../modules/src.cmake

--- a/test/python_libs_custom/src/CMakeLists.txt
+++ b/test/python_libs_custom/src/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(example example.cpp)
+target_link_libraries(example ${PYTHON_LIBRARIES})

--- a/test/python_libs_custom/src/example.cpp
+++ b/test/python_libs_custom/src/example.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <Python.h>
+
+int main(int argc, char *argv[])
+{
+    Py_SetProgramName(argv[0]);  /* optional but recommended */
+    Py_Initialize();
+    PyRun_SimpleString("print('PASSED')\n");
+    Py_Finalize();
+    return 0;
+}

--- a/test/test.py
+++ b/test/test.py
@@ -193,3 +193,21 @@ def test_fc_lapack():
 @skip_on_windows
 def test_fc_lapack_static():
     configure_build_and_exe('fc_lapack', 'python setup.py --fc=gfortran --static --cmake-options="-DMATH_LIB_SEARCH_ORDER=\'ATLAS;MKL\'"')
+
+
+def test_python_interpreter():
+    configure_build_and_exe('python_interpreter', 'python setup.py --cxx=g++')
+
+
+def test_python_interpreter_custom():
+    python_executable = sys.executable
+    configure_build_and_exe('python_interpreter_custom', 'python setup.py --cxx=g++ --python={}'.format(python_executable))
+
+
+def test_python_libs():
+    configure_build_and_exe('python_libs', 'python setup.py --cxx=g++')
+
+
+def test_python_libs_custom():
+    python_executable = sys.executable
+    configure_build_and_exe('python_libs_custom', 'python setup.py --cxx=g++ --python={}'.format(python_executable))


### PR DESCRIPTION
Changes to the Python detection:
*  The detection is now split into interpreter and libraries/headers. There are two modules: python_interpreter.cmake and python_libs.cmake. They mimick the behaviour of the standard CMake modules. The latter module depends on the former: the CMake admin has to take care of this.
* The python_interpreter.cmake module sets a --python option in the setup.py script. The end-user can thus set his/her own installation of the interpreter (and thus also libraries/headers) *via* command-line
* Tests were added for both the python_interpreter.cmake and the python_libs.cmake with and without explicit specification of an interpreter from the user. 
* For the python_libs.cmake test the [basic embedding example](https://docs.python.org/2/extending/embedding.html#very-high-level-embedding) from the Python documentation was copy-pasted.
* .travis.yml know installs libpython-dev prior to test execution.

Possible limitations and ideas for further work:
* The only way to specify that a working interpreter is required is to hardcoded the information **after** the project has been bootstrapped.
* Same goes for minimum required version specification. It has to be hardcoded **after** project bootstrap was done.
* The python_interpreter.cmake test cases compile a dummy C++ example program. Thus only detection is tested of the interpreter is currently tested. It might be appropriate to also try and use the interpreter.