### PR TITLE
Fix for Python 3 failing builds on Windows CI workers

### DIFF
--- a/test/python_libs/src/example.cpp
+++ b/test/python_libs/src/example.cpp
@@ -3,7 +3,6 @@
 
 int main(int argc, char *argv[])
 {
-    Py_SetProgramName(argv[0]);  /* optional but recommended */
     Py_Initialize();
     PyRun_SimpleString("print('PASSED')\n");
     Py_Finalize();

--- a/test/python_libs_custom/src/example.cpp
+++ b/test/python_libs_custom/src/example.cpp
@@ -3,7 +3,6 @@
 
 int main(int argc, char *argv[])
 {
-    Py_SetProgramName(argv[0]);  /* optional but recommended */
     Py_Initialize();
     PyRun_SimpleString("print('PASSED')\n");
     Py_Finalize();


### PR DESCRIPTION
The signature of the Py_SetProgramName has changed in a way that is not backwards compatible.
Since the call is optional, certainly not needed for this simple test, I removed it.