### PR TITLE
math_libs.cmake: remove "-lc" linking flag, not necessary

### DIFF
--- a/modules/math_libs.cmake
+++ b/modules/math_libs.cmake
@@ -509,8 +509,7 @@ if (ENABLE_STATIC_LINKING)
     endif()
     if (LAPACK_TYPE MATCHES MKL OR
         BLAS_TYPE MATCHES MKL)
-        # fix for MKL static linking (-lc not needed for PGI)
-        # radovan: why is -lc added also for PGI? when exactly is it needed?
-        set(MATH_LIBS ${MATH_LIBS} -ldl -lc)
+        # fix for MKL static linking 
+        set(MATH_LIBS ${MATH_LIBS} -ldl)
     endif()
 endif()


### PR DESCRIPTION
PGI+MKL+i8-STATIC:

Fix this linking problem found with DIRAC - simply remove the redundant "-lc" linking flag. 


~~~
Linking Fortran executable dirac_mointegral_export.x
/usr/lib64/libpthread.a(libpthread.o): In function `__libc_sigaction':
(.text+0x9a40): multiple definition of `__libc_sigaction'
/usr/lib64/libc.a(sigaction.o):(.text+0x20): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__connect_nocancel':
(.text+0x8e19): multiple definition of `__connect_nocancel'
/usr/lib64/libc.a(connect.o):(.text+0x9): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `fcntl':
(.text+0x8c60): multiple definition of `__libc_fcntl'
/usr/lib64/libc.a(fcntl.o):(.text+0xf0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__funlockfile':
(.text+0x99e0): multiple definition of `_IO_funlockfile'
/usr/lib64/libc.a(funlockfile.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `read':
(.text+0x8ab0): multiple definition of `__libc_read'
/usr/lib64/libc.a(read.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__open_nocancel':
(.text+0x92d9): multiple definition of `__open_nocancel'
/usr/lib64/libc.a(open.o):(.text+0x9): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__lseek_nocancel':
(.text+0x91b9): multiple definition of `__lseek_nocancel'
/usr/lib64/libc.a(llseek.o):(.text+0x9): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__read_nocancel':
(.text+0x8ab9): multiple definition of `__read_nocancel'
/usr/lib64/libc.a(read.o):(.text+0x9): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__libc_send':
(.text+0x8fe0): multiple definition of `__libc_send'
/usr/lib64/libc.a(send.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `close':
(.text+0x8b10): multiple definition of `__libc_close'
/usr/lib64/libc.a(close.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__open64':
(.text+0x92d0): multiple definition of `__libc_open'
/usr/lib64/libc.a(open.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__write_nocancel':
(.text+0x8a59): multiple definition of `__write_nocancel'
/usr/lib64/libc.a(write.o):(.text+0x9): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__close_nocancel':
(.text+0x8b19): multiple definition of `__close_nocancel'
/usr/lib64/libc.a(close.o):(.text+0x9): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__fcntl_nocancel':
(.text+0x8b70): multiple definition of `__fcntl_nocancel'
/usr/lib64/libc.a(fcntl.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `lseek64':
(.text+0x91b0): multiple definition of `__libc_lseek'
/usr/lib64/libc.a(llseek.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__sigaction':
(.text+0x9c40): multiple definition of `__sigaction'
/usr/lib64/libc.a(sigaction.o):(.text+0x220): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__funlockfile':
(.text+0x99e0): multiple definition of `__funlockfile'
/usr/lib64/libc.a(funlockfile.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__lll_lock_wait_private':
(.text+0x85a0): multiple definition of `__lll_lock_wait_private'
/usr/lib64/libc.a(libc-lowlevellock.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__libc_write':
(.text+0x8a50): multiple definition of `__libc_write'
/usr/lib64/libc.a(write.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__libc_connect':
(.text+0x8e10): multiple definition of `__libc_connect'
/usr/lib64/libc.a(connect.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `__lll_unlock_wake_private':
(.text+0x8730): multiple definition of `__lll_unlock_wake_private'
/usr/lib64/libc.a(libc-lowlevellock.o):(.text+0x30): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `raise':
(.text+0x98d0): multiple definition of `raise'
/usr/lib64/libc.a(raise.o):(.text+0x0): first defined here
/usr/lib64/libpthread.a(libpthread.o): In function `sem_open':
(.text+0x774d): warning: the use of `mktemp' is dangerous, better use `mkstemp'
make[3]: *** [dirac_mointegral_export.x] Error 2
make[2]: *** [CMakeFiles/dirac_mointegral_export.x.dir/all] Error 2
make[1]: *** [CMakeFiles/dirac_mointegral_export.x.dir/rule] Error 2
make: *** [dirac_mointegral_export.x] Error 2
~~~