### PR TITLE
Add module for ccache support.

### DIFF
--- a/modules/ccache.cmake
+++ b/modules/ccache.cmake
@@ -1,0 +1,27 @@
+#.rst:
+#
+# Adds ccache support.
+# The user should export the appropriate environment variables to
+# tweak the program's behaviour, as described in its manpage.
+# Notice that some additional compiler flags might be needed in order
+# to avoid unnecessary warnings.
+#
+# Variables defined::
+#
+#   CCACHE_FOUND
+#
+# autocmake.cfg configuration::
+#
+#   docopt: --ccache=<USE_CCACHE> Toggle use of ccache <ON/OFF> [default: ON].
+#   define: '-DUSE_CCACHE="{0}"'.format(arguments['--ccache'])
+
+if(USE_CCACHE)
+    find_program(CCACHE_FOUND ccache)
+    if(CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+        message(STATUS "Compiling with ccache")
+    else()
+        message(STATUS "ccache not available")
+    endif()
+endif()


### PR DESCRIPTION
It's based on information retrieved from:
https://www.virag.si/2015/07/use-ccache-with-cmake-for-faster-compilation/
http://petereisentraut.blogspot.no/2011/05/ccache-and-clang.html

I have tested it on my laptop with GCC 4.9.1 and Clang 3.5.0 It should also work with Intel compilers, but I don't have a way of testing it.