### PR TITLE
fix python failure on my Linux cluster

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -176,7 +176,7 @@ def test_python_libs():
 @skip_on_windows
 def test_python_libs_custom():
     python_executable = sys.executable
-    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python=' + (python_executable) )
+    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python=' + (python_executable))
 
 
 @skip_on_windows

--- a/test/test.py
+++ b/test/test.py
@@ -176,7 +176,7 @@ def test_python_libs():
 @skip_on_windows
 def test_python_libs_custom():
     python_executable = sys.executable
-    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python='+(python_executable))
+    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python=' + (python_executable) )
 
 
 @skip_on_windows

--- a/test/test.py
+++ b/test/test.py
@@ -176,7 +176,7 @@ def test_python_libs():
 @skip_on_windows
 def test_python_libs_custom():
     python_executable = sys.executable
-    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python={}'.format(python_executable))
+    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python='+(python_executable))
 
 
 @skip_on_windows

--- a/test/test.py
+++ b/test/test.py
@@ -175,8 +175,7 @@ def test_python_libs():
 
 @skip_on_windows
 def test_python_libs_custom():
-    python_executable = sys.executable
-    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python=' + (python_executable))
+    configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python=' + sys.executable)
 
 
 @skip_on_windows


### PR DESCRIPTION
On
Linux login 2.6.32-504.23.4.el6.x86_64 #1 SMP Tue Jun 9 11:55:03 CDT 2015 x86_64 x86_64 x86_64 GNU/Linux

Python 2.6.6


to fix  
~~~
====================================================================== FAILURES ======================================================================
______________________________________________________________ test_python_libs_custom _______________________________________________________________

    def test_python_libs_custom():
        python_executable = sys.executable
        print python_executable
>       configure_build_and_exe('python_libs_custom', 'python setup --cxx=g++ --python={}'.format(python_executable))
E       ValueError: zero length field name in format

test.py:176: ValueError
~~~