### PR TITLE
provide threaded essl library only

### DIFF
--- a/modules/math_libs.cmake
+++ b/modules/math_libs.cmake
@@ -88,8 +88,8 @@ if(ENABLE_64BIT_INTEGERS)
    set(ESSL_BLAS_LIBS   esslsmp6464)
    set(ESSL_LAPACK_LIBS esslsmp6464)
 else()
-   set(ESSL_BLAS_LIBS   essl)
-   set(ESSL_LAPACK_LIBS essl)
+   set(ESSL_BLAS_LIBS   esslsmp)
+   set(ESSL_LAPACK_LIBS esslsmp)
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
It's better to use threaded essl library on IBM AIX, could we have it please ?

Standard IBM AIX has both library types:
~~~
ilias@f01c10n02:~/work/qch/software/dirac/trunk/cmake/downloaded/.ar t /usr/lib/libesslsmp.a
essl.o
ilias@f01c10n02:~/work/qch/software/dirac/trunk/cmake/downloaded/.ar t /usr/lib/libessl.a
essl.o
ilias@f01c10n02:~/work/qch/software/dirac/trunk/cmake/downloaded/.
~~~